### PR TITLE
Image for Latency Sim transport variable

### DIFF
--- a/manual/transports/latency-simulaton-transport.md
+++ b/manual/transports/latency-simulaton-transport.md
@@ -15,3 +15,5 @@ Reliable messages are ordered and guaranteed delivery by definition. Packet loss
 {% endhint %}
 
 ![](../../.gitbook/assets/2021-03-14\_21-32-23@2x.png)
+
+![NMLatencySim](https://user-images.githubusercontent.com/57072365/225437999-0667da1b-abf7-49c5-8c1d-d1a2fec36b12.jpg)


### PR DESCRIPTION
Visually points out a possible step that could be missed, regarding variable on Network Manager.