### PR TITLE
Error correction. Missing a space

### DIFF
--- a/trivia/a-history-of-mirror.md
+++ b/trivia/a-history-of-mirror.md
@@ -21,7 +21,7 @@ Back in summer 2015 Unity released a public beta of **UNET**. The idea of Unity 
 * **Server & Client in one project**. Most of the code is shared. Some is marked as \[Server] or \[Client] only.
   * This allows for a major gain productivity since terrain, models, assets and code are all shared between server & client.
 * **\[SyncVars]** for automated serialization of selected variables.&#x20;
-  * This was significant when coming from hand built Serialize/Deserialize functions. Simply adding a \[SyncVar] in front of Player.level was so much easier.
+  * This was significant when coming from hand built Serialize/Deserialize functions. Simply adding a \[SyncVar] in front of Player. level was so much easier.
 * **\[Commands/Rpcs]** - wrapping a function with a \[Command] tag to automatically call it on the server was another huge gain productivity
   * Compared to manually sending a message, deserializing all parameters and calling a function manually.&#x20;
 


### PR DESCRIPTION
In the sentence about SyncVar, a space after the dot was omitted
![image](https://github.com/MirrorNetworking/MirrorDocs/assets/76999364/951318af-1288-4b60-815f-2a409ed321e6)
