### PR TITLE
Fixed a spelling mistake in the Examples main page for clarity

### DIFF
--- a/manual/examples/README.md
+++ b/manual/examples/README.md
@@ -62,4 +62,4 @@ Only a select few have documentation pages, check the Mirror/Examples directory 
 * Tanks Co-Op\
   &#x20;Take control of tank Vehicles, spawn as regular player prefab, interact with tank to enter, drive and shoot, exit to continue being regular player.
 * VR\
-  &#x20;A selectoin of multiplayer-ready virtual reality examples that use Unitys XR toolkit, allows the use of multiple VR headsets with one setup.&#x20;
+  &#x20;A selection of multiplayer-ready virtual reality examples that use Unitys XR toolkit, allows the use of multiple VR headsets with one setup.&#x20;


### PR DESCRIPTION
Section read: VR
A _selectoin_ of multiplayer-ready virtual reality examples that use Unitys XR toolkit, allows the use of multiple VR headsets with one setup.

Amended to read:
A _selection_ of multiplayer-ready virtual reality examples that use Unitys XR toolkit, allows the use of multiple VR headsets with one setup.