### PR TITLE
Replace Guid with uint

### DIFF
--- a/manual/guides/gameobjects/custom-spawnfunctions.md
+++ b/manual/guides/gameobjects/custom-spawnfunctions.md
@@ -9,7 +9,7 @@ The Spawn / Unspawn delegates will look something like this:
 **Spawn Handler**
 
 ```csharp
-GameObject SpawnDelegate(Vector3 position, System.Guid assetId) 
+GameObject SpawnDelegate(Vector3 position, uint assetId) 
 {
     // do stuff here
 }
@@ -39,7 +39,8 @@ When a prefab is saved its `assetId` field will be automatically set. If you wan
 
 ```csharp
 // generate a new unique assetId 
-System.Guid creatureAssetId = System.Guid.NewGuid();
+System.Guid creatureAssetGuid = System.Guid.NewGuid();
+uint creatureAssetId = NetworkIdentity.AssetGuidToUint(creatureAssetGuid);
 
 // register handlers for the new assetId
 NetworkClient.RegisterSpawnHandler(creatureAssetId, SpawnCreature, UnSpawnCreature);


### PR DESCRIPTION
There is outdated code in the docs since Guid was replaced with uint in v69:
"breaking: perf: assetId as uint instead of Guid"
https://github.com/MirrorNetworking/Mirror/releases/tag/2022_10

Would be nice to see mapping helper method in the code example in the docs (I found the method accidentally):
https://github.com/MirrorNetworking/Mirror/blob/master/Assets/Mirror/Core/NetworkIdentity.cs#L368