### PR TITLE
SyncDictionary OnChange - key represents old value

### DIFF
--- a/manual/guides/synchronization/syncdictionary.md
+++ b/manual/guides/synchronization/syncdictionary.md
@@ -61,9 +61,12 @@ public class ExamplePlayer : NetworkBehaviour
                 break;
             case SyncIDictionary<string, Item>.Operation.OP_SET:
                 // entry changed
+                // "Item item" is the OLD value
+                // Get the new value from 'Equipment[key]'
                 break;
             case SyncIDictionary<string, Item>.Operation.OP_REMOVE:
                 // entry removed
+                // "Item item" is the OLD value
                 break;
             case SyncIDictionary<string, Item>.Operation.OP_CLEAR:
                 // Dictionary was cleared


### PR DESCRIPTION
It took me a while to understand that in OP_SET and OP_REMOVE operations, the key actually represented the old value.
The action description shows it but the documentation does not. Could be helpful.

![Screenshot 2024-08-27 at 16 22 21](https://github.com/user-attachments/assets/9f7a7d15-7e1e-4cbc-9d10-2bc2ebfca548)
