### PR TITLE
Update EOSTranport in docs

### DIFF
--- a/manual/transports/README.md
+++ b/manual/transports/README.md
@@ -5,9 +5,9 @@
 These transports are included with Mirror.
 
 * [KCP ](kcp-transport.md)UDP transport based on kcp.c, line-by-line translation to C#
-* [Telepathy](telepathy-transport.md) - Simple, message based, MMO Scale TCP networking in C#. And no magic.
-* [Simple Web Sockets](websockets-transport/) - WebGL transport layer for Mirror that target browser clients.
-* [Multiplexer](multiplex-transport.md) - Bridging transport to allow a server to handle clients on different transports concurrently, for example desktop clients using Telepathy together with WebGL clients using Websockets.
+* [Telepathy](telepathy-transport.md) - Simple, message-based, MMO Scale TCP networking in C#. And no magic.
+* [Simple Web Sockets](websockets-transport/) - WebGL transport layer for Mirror that targets browser clients.
+* [Multiplexer](multiplex-transport.md) - Bridging transport to allow a server to handle clients on different transports concurrently, for example, desktop clients using Telepathy together with WebGL clients using Websockets.
 * [Latency Simulation](latency-simulaton-transport.md) - Middleman transport to test non-ideal network conditions
 * [Encryption](encryption-transport.md) - Middleman transport to encrypt a different transport
 * [Edgegap Relay Transports](edgegap-transports/) - Transports to utilize [Edgegaps Destributed Relay](https://edgegap.com/en/platform/distributed-relay) Service
@@ -25,7 +25,7 @@ These transports are maintained by third parties outside of Mirror.
 These transports are maintained by third parties and use relay infrastructure to connect clients to servers behind firewalls / NAT.
 
 * [Steam - FizzySteamworks](fizzysteamworks-transport.md) - Transport utilizing Steam P2P network, building on [Steamworks.NET](https://github.com/rlabrecque/Steamworks.NET).
-* [Epic - Epic Online Services](https://github.com/Ludogram/EpicOnlineTransport) - Relay transport utilizing Epic's free relay service.
+* [Epic - Epic Online Services](https://github.com/WeLoveJesusChrist/EOSTransport) - Relay transport utilizing Epic's free relay service.
 * [LRM - Light Reflective Mirror](https://github.com/Speidy674/Light-Reflective-Mirror) - Relay transport for WebGL clients.
 
 ## Changing Transports


### PR DESCRIPTION
Just updated the EOSTransport link in the docs, and fixed some grammar issues.